### PR TITLE
Added ability to register PipelineRD as Transient, Scoped, or Singleton, and appropriate unit tests for Transient only

### DIFF
--- a/src/PipelineRD/Builders/IPipelineServicesBuilder.cs
+++ b/src/PipelineRD/Builders/IPipelineServicesBuilder.cs
@@ -5,14 +5,16 @@ using System.Reflection;
 
 namespace PipelineRD.Builders
 {
+    using Enums;
+
     public interface IPipelineServicesBuilder
     {
-        void InjectContexts();
-        void InjectSteps();
-        void InjectPipelines();
-        void InjectPipelineInitializers();
-        void InjectPipelineBuilders();
-        void InjectAll();
+        void InjectContexts(InjectionLifetime? lifetime = null);
+        void InjectSteps(InjectionLifetime? lifetime = null);
+        void InjectPipelines(InjectionLifetime? lifetime = null);
+        void InjectPipelineInitializers(InjectionLifetime? lifetime = null);
+        void InjectPipelineBuilders(InjectionLifetime? lifetime = null);
+        void InjectAll(InjectionLifetime? lifetime = null);
 
         IEnumerable<TypeInfo> Types { get; }
         IServiceCollection Services { get; }

--- a/src/PipelineRD/Enums/InjectionLifetime.cs
+++ b/src/PipelineRD/Enums/InjectionLifetime.cs
@@ -1,0 +1,10 @@
+﻿namespace PipelineRD.Enums;
+
+public enum InjectionLifetime
+{
+    Scoped,
+
+    Transient,
+
+    Singleton
+}

--- a/src/PipelineRD/PipelineRD.csproj
+++ b/src/PipelineRD/PipelineRD.csproj
@@ -25,4 +25,8 @@
     <PackageReference Include="WebApi.Models" Version="1.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Enums\" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
# Intro

Hello! First of all I am very happy to come across your library! I think it is very very cool.  I like the pipeline pattern because it easily allows the developer to chain multiple small 'nodes' (steps as you call it) code together, mix and match the steps, and create workflows.

Originally I was using this library: [CommandLib](https://github.com/efieleke/CommandLib) for Workflows, its quite good, albeit a bit confusing and a the code is a bit 'old', but it worked and served the purpose.  I hit a wall with [CommandLib](https://github.com/efieleke/CommandLib) because it did not support dependency injection.

I did much research and I found your library! Also, the 'auto-generating' workflow documentation is VERY VERY COOL!!!

## What the problem is

When I downloaded your library, and ran the example so that I can learn more, it helped my understanding. Upon testing, I realized that I was receiving strange results due to the dependency injection's registered as 'Scoped'.  I understand why you have it registered as 'Scoped', and 'Singleton' in some cases, and that makes sense.

When I performed the scenario below, I encountered weird errors upon testing 'how many times a step or rollback executed'.  The errors were due to the 'scope' dependency injection lifetime. See below:

**Example to produce unexpected results due to shared context between methods, WITHIN the 'Scoped' lifetime **

````csharp

// App is registered as transient and ran by a console application (Irrelevant) 
public class App
{
    private readonly IBankPipelineBuilder _bankPipelineBuilder;

    public App(IBankPipelineBuilder bankPipelineBuilder)
    {
        this._bankPipelineBuilder = bankPipelineBuilder;
    }

#pragma warning disable CS1998
    public async Task RunAsync()
#pragma warning restore CS1998
    {
        // Insert program code below...  
        var accounts = this._getAccounts("SP", "First", "Second",
            "Third");

        foreach (var account in accounts)
        {
            // This will run and add 'values' to the context
            await this._bankPipelineBuilder.CreateAccount(account);

            var depositAccount = new DepositAccountModel
            {
                Nome = account.Cidade
            };

            // This will also run and add values to the context, because the pipeline is 'scoped', this will produce irregular results depending on what 
            // values the 'createAccount' method added
            await this._bankPipelineBuilder.DepositAccount(depositAccount);
        }
    }

    private List<CreateAccountModel> _getAccounts(params string[] names)
    {
        var result = new List<CreateAccountModel>();

         foreach (var n in names)
        {
            result.Add(new CreateAccountModel
            {
                Cidade = n
            });
        }

        return result;
    }
}

````

### Solutions

I realized the the solution to this was (1) of (2) solutions.

#### **Solution 1**

- **Adopt a 'best practice' in which each Pipeline 'method' had it's own context.**  
This is to ensure that other methods do not accidently produce irregular results due to interference with other methods.  Its a good solution, and it does work of course without any code changes.

#### **Solution 2** 

- Allow the PipelineRD to be configured more 'easily' with various lifetimes for DI.

This allows me to configure the above as 'Transient', and the errors will go away. However, some errors can be produced as you see from the Transient tests, as now if you resolve a 'step', the step will be a clean-slate compared to being 'pre-populated' due to previously registered values.  Its just something to keep in mind.


I added these _optional_ enum values.  The default value is 'scoped' as you had it configured

````csharp
public enum InjectionLifetime
{
    Scoped,

    Transient,

    Singleton
}
````

Now a user can configure DI like this:

````csharp
  private IServiceProvider _getTransientServiceProvider()
        {
            var services = new ServiceCollection();
            services.UsePipelineRD(x =>
            {
                x.UseCacheInMemory(new PipelineRD.Settings.MemoryCacheSettings());

                //Note the Enum value
                x.AddPipelineServices(x => x.InjectAll(InjectionLifetime.Transient));
            });

            services.AddSingleton<ISampleCondition, SampleCondition>();

            return services.BuildServiceProvider();
        }

````

or like this

````csharp

// A user can inject the InjectionLifetime enum into any one of the DI configuration methods.
// The user will need to be mindful not to inject incorrect lifetimes such as a 'Transient' lifetime into a
// 'Scoped' lifetime or they will encounter strange results due to the shared DI container.

  public void InjectAll(InjectionLifetime? lifetime = null)
        {
            lifetime ??= InjectionLifetime.Scoped;
            InjectContexts(lifetime);
            InjectSteps(lifetime);
            InjectPipelineBuilders(lifetime);
            InjectPipelineInitializers(lifetime);
            InjectPipelines(lifetime);
        }

````

# End 

This is your library, I did not open a ticket or issue, let me know what you think and I can make any changes as you see fit!!
